### PR TITLE
Force create missing functions for getMetaClass

### DIFF
--- a/ida_kernelcache/ida_helpers/instructions.py
+++ b/ida_kernelcache/ida_helpers/instructions.py
@@ -1,0 +1,41 @@
+import idautils
+from ida_funcs import func_t
+from ida_ua import insn_t
+
+
+def decode_instruction(ea: int) -> insn_t | None:
+    """Decode an instruction at the given ea"""
+    return idautils.DecodeInstruction(ea)
+
+
+def decode_next_instruction(insn: insn_t, func: func_t) -> insn_t | None:
+    """Decode the next instruction after the given insn"""
+    next_ea = insn.ea + insn.size
+    if next_ea >= func.end_ea:
+        return None
+
+    return decode_instruction(next_ea)
+
+
+def decode_previous_instruction(insn: insn_t) -> insn_t | None:
+    """Decode the previous instruction for the given insn"""
+    return idautils.DecodePrecedingInstruction(insn.ea)[0]
+
+
+def get_previous(ea: int, canon_name: str, previous_opcode_count: int) -> int | None:
+    """Given an ea, search up until reaching an instruction with {canon_name}"""
+    insn = decode_instruction(ea)
+    if not insn:
+        return None
+
+    if insn.get_canon_mnem() == canon_name:
+        return ea
+
+    for _ in range(previous_opcode_count):
+        insn = decode_previous_instruction(insn)
+        # No more instructions in this execution flow
+        if insn is None:
+            break
+        if insn.get_canon_mnem() == canon_name:
+            return insn.ea
+    return None

--- a/ida_kernelcache/phases/collect_classes.py
+++ b/ida_kernelcache/phases/collect_classes.py
@@ -157,7 +157,7 @@ class CollectClasses(BasePhase):
             # choose to skip them.
             for xref_ea in idautils.CodeRefsTo(self.osmetaclass_constructor_ea, flow=False):
                 self._num_xrefs += 1
-                func_start_ea = functions.get_func_start(xref_ea)
+                func_start_ea = functions.get_func_start_or_try_create(xref_ea)
                 self._visited.add(func_start_ea)
                 if self._handle_callsite(xref_ea):
                     self._num_succeeded += 1


### PR DESCRIPTION
On 26 Beta 4 for iPhone 16 pro, IDA 9.0 does not detect some of the `getMetaClass()` functions.
As a patch, I've created `get_func_start_or_try_create` which tries to create the function for those cases.
This is kinda hack so if you want you can close the PR and implement it yourself.