### PR TITLE
Symbolification improvements

### DIFF
--- a/ida_kernelcache/phases/create_types.py
+++ b/ida_kernelcache/phases/create_types.py
@@ -100,13 +100,18 @@ class CreateTypes(BasePhase):
                     # Might raise StringExtractionError or DemanglingError
                     func_name = symbols.extract_method_name(vtable_entry.vmethod_info.mangled_symbol)
 
-                # TODO: IDA has a bug that does will fail to parse vtable declaration if two vmethods have the same name,
-                #  even if they have a different signature.
+                # IDA has a bug that does will fail to parse vtable declaration if two vmethods have the same name,
+                # even if they have a different signature. We will add a suffix to the function name in this case.
                 if func_name in func_names:
                     func_name_conflicts += 1
 
-                    # TODO: maybe just add a running suffix
-                    func_name = consts.VMETHOD_NAME_TEMPLATE.format(index=vtable_entry.index)
+                    for i in range(20):
+                        new_func_name = f'{func_name}{i}'
+                        if new_func_name not in func_names:
+                            func_name = new_func_name
+                            break
+                    else:
+                        func_name = consts.VMETHOD_NAME_TEMPLATE.format(index=vtable_entry.index)
 
                 func_names.add(func_name)
 

--- a/ida_kernelcache/rtti.py
+++ b/ida_kernelcache/rtti.py
@@ -209,9 +209,12 @@ class VtableEntry:
     def __eq__(self, other):
         return self.entry_ea == other.entry_ea
 
+    @property
+    def has_symbol(self) -> bool:
+        return bool(self.vmethod_info and self.vmethod_info.mangled_symbol)
+
     def __repr__(self) -> str:
-        has_symbol = int(bool(self.vmethod_info and self.vmethod_info.mangled_symbol))
-        return f'VtableEntry(index={self.index}, entry_ea={self.entry_ea:#x}, pac_diversifier={self.pac_diversifier:#x}, o={int(self.overrides)}, i={int(self.inherited)}, pv={int(self.pure_virtual)}, a={int(self.added)}, symbolicated={has_symbol})'
+        return f'VtableEntry(index={self.index}, entry_ea={self.entry_ea:#x}, pac_diversifier={self.pac_diversifier:#x}, o={int(self.overrides)}, i={int(self.inherited)}, pv={int(self.pure_virtual)}, a={int(self.added)}, symbolicated={int(self.has_symbol)})'
 
 
 class VtableInfo:

--- a/tasks.todo
+++ b/tasks.todo
@@ -21,6 +21,7 @@ Symbolication:
   ✔ Implement getting the PAC diversifier of every vtable entry @done(25-01-27 11:47)
   ✔ Fix errors "does not seem to be a signed PAC pointer". UPDATE: seems like some objects are subject to multiple inheritance? In the past this was not supported by libkern++ @done(25-01-27 11:47)
         according to Apple's documentation. There are these sentinels and non virtual thunks, weird. On a recent kernelcache there are 93 classes that contain a sentinel.
+  ☐ Create PAC Signatures for pure virtual methods, including OSMetaClassBase methods that OSObject implements.
 
 Get rid of old code!:
   ✔ Delete old and unused scripts! @done(25-01-27 11:47)


### PR DESCRIPTION
## Fix vtable function name conflict using a numeric suffix

I think it is better than the current implementation. No ideal, but as long as there is no support for it in IDA its the best I can think of.

## Fix PAC Symbolicate algorithm.

The signature on the func `C::f` is:
  - if `f` was added in `C`, then `hash(C::f)`
  - Otherwise it was added in some `B` parent of `C`, so the hash is `hash(B::f)`.
 Therefore, the algorithm should be simply:
- If `vmethod_xx` was added, search for the signature only in the same class
- If it is an override, take the name from parent.

As a TODO, we need to generate names for pure virtual methods (which use the parent symbol to call, but the symbol is not available on binary). Also, we could use iOS 16.5 symbols as well to enrich. Finally, we need to support `OSMetaClassBase` methods that we ignore and say they are of `OSObject`.

Another TODO is figure why it still doesn't work for some methods, like `__ZNK15IORegistryEntry11setPropertyEPKcS1_` (method indexed 26 of IORegistryEntry). It is the same name as 16.4 so I wonder what could be the reason.